### PR TITLE
feat: improve Gmail validation error message clarity

### DIFF
--- a/opensource/frontend/register.html
+++ b/opensource/frontend/register.html
@@ -209,7 +209,7 @@
                     document.getElementById('emailError').innerText = 'Email is too long.';
                     isValid = false;
                 } else if (emailInput.value.endsWith('@gmail.com') && !emailRegex.test(emailInput.value)) {
-                    document.getElementById('emailError').innerText = 'Gmail addresses cannot contain "." or "+" symbols before the "@". Please remove these symbols.';
+                    document.getElementById('emailError').innerText = 'Gmail addresses cannot contain "." or "+" symbols before the "@". Please remove these symbols. Gmail treats john.doe@gmail.com or john+doe@gmail.com as aliases of johndoe@gmail.com';
                     isValid = false;
                 } else {
                     document.getElementById('emailError').innerText = '';


### PR DESCRIPTION
Enhanced the error message for Gmail addresses in the registration form to better explain why dots and plus signs are not allowed. The new message clarifies that Gmail treats addresses like john.doe@gmail.com or john+doe@gmail.com as aliases of johndoe@gmail.com, helping users understand the validation requirement.

<img width="757" height="228" alt="Screenshot 2025-08-24 at 5 51 02 PM" src="https://github.com/user-attachments/assets/94dbe9e2-bc5e-4eee-af4e-c89d7f31cf01" />
